### PR TITLE
Add 'NO DATA AVAILABLE' label when there are no data.

### DIFF
--- a/src/ng-dygraphs.component.css
+++ b/src/ng-dygraphs.component.css
@@ -19,6 +19,21 @@
   .ng-dygraphs .ng-dygraphs-chart-container {
     background-color: #fff;
     padding: 24px; }
+    .ng-dygraphs .ng-dygraphs-chart-container .nodata {
+      display: -webkit-flex;
+      display: -ms-flexbox;
+      display: flex;
+      -webkit-box-pack: center;
+         -ms-flex-pack: center;
+       justify-content: center;
+     -webkit-box-align: center;
+        -ms-flex-align: center;
+           align-items: center; }
+    .ng-dygraphs .ng-dygraphs-chart-container .nodata::before {
+      content: 'NO DATA AVAILABLE';
+      color: #5c5c5c;
+      font-weight: bold;
+      font-size: 24px; }
   .ng-dygraphs .loader-holder {
     position: absolute;
     display: -webkit-flex;

--- a/src/ng-dygraphs.component.html
+++ b/src/ng-dygraphs.component.html
@@ -11,6 +11,7 @@
         </div>
     </div>
     <div class="ng-dygraphs-chart-container">
-        <div #chart [style.width.px]="chartWidth" [style.height.px]="chartHeight"></div>
+        <div *ngIf="data?.length" #chart [style.width.px]="chartWidth" [style.height.px]="chartHeight"></div>
+        <div *ngIf="!data?.length" class="nodata" [style.width.px]="chartWidth" [style.height.px]="chartHeight"></div>
     </div>
 </div>

--- a/src/ng-dygraphs.component.ts
+++ b/src/ng-dygraphs.component.ts
@@ -19,7 +19,7 @@ export class NgDygraphsComponent implements OnInit, OnChanges {
   @Input() customVisibility: boolean;
   @ViewChild('chart') chart: ElementRef;
 
-  public loadingInProgress = true;
+  public loadingInProgress: boolean;
   public chartWidth: number;
   public chartHeight: number;
   public labels: string[];
@@ -39,7 +39,12 @@ export class NgDygraphsComponent implements OnInit, OnChanges {
    * @return {void}
    */
   ngOnChanges() {
-    if (!this.data || !this.data.length) { return; };
+    if (!this.data || !this.data.length) {
+      this.loadingInProgress = false;
+      return;
+    };
+
+    this.loadingInProgress = true;
 
     const options = Object.assign({}, this.options);
 
@@ -59,8 +64,6 @@ export class NgDygraphsComponent implements OnInit, OnChanges {
       });
     }
     if (options.labels) { options.visibility = initialVisibility; }
-
-    this.loadingInProgress = true;
 
     setTimeout(() => {
       this._g = new Dygraph(this.chart.nativeElement,


### PR DESCRIPTION
This PR shows a `NO DATA AVAILABLE` label in place of the chart in case there are no data.

`loadingInProgress` has been brought before the `options` check in order for the `loader` to be displayed in case the check takes a while.

`loadingInProgress` has been also added, before the `return` statement when there are no data, in order to hide the `loader` if it's previously shown and an error occurred on the previous chart.

@mpx200 You may want to change the label with an image. I don't know your preferences so I went with the simplest solution. 
