### PR TITLE
Fix issue with missing 'chart' element in DOM.

### DIFF
--- a/src/ng-dygraphs.component.css
+++ b/src/ng-dygraphs.component.css
@@ -28,14 +28,14 @@
        justify-content: center;
      -webkit-box-align: center;
         -ms-flex-align: center;
-           align-items: center; }
-    .ng-dygraphs .ng-dygraphs-chart-container .nodata {
+           align-items: center;
       color: #5c5c5c;
       font-weight: bold;
       font-size: 24px; 
       display: flex;
-      align-content: center;
-      }
+      align-content: center; }
+    .ng-dygraphs .ng-dygraphs-chart-container .hide {
+       display: none; }
   .ng-dygraphs .loader-holder {
     position: absolute;
     display: -webkit-flex;

--- a/src/ng-dygraphs.component.html
+++ b/src/ng-dygraphs.component.html
@@ -11,7 +11,7 @@
         </div>
     </div>
     <div class="ng-dygraphs-chart-container">
-        <div *ngIf="data?.length" #chart [style.width.px]="chartWidth" [style.height.px]="chartHeight"></div>
+        <div [ngClass]="{'hide': !data?.length}" #chart [style.width.px]="chartWidth" [style.height.px]="chartHeight"></div>
         <div *ngIf="!data?.length" class="nodata" [style.width.px]="chartWidth" [style.height.px]="chartHeight">
           {{noDataLabel}}
         </div>


### PR DESCRIPTION
Unfortunately my last PR introduced an unseen issue.

The use case is that when there are no data available and the `noDataLabel` gets displayed, `#chart` element is not present in the DOM, in order for `Dygraph` to plot the data when they are available again.
The error message is `TypeError: Cannot read property 'nativeElement' of undefined` which relates to `this.chart` @ https://github.com/mpx200/ng-dygraphs/blob/master/src/ng-dygraphs.component.ts#L71

`#chart` needs to **always** be present in the DOM, therefore we need to show/hide it and not add/remove it.

Sorry for any inconvenience caused.